### PR TITLE
Add 'disconnect' event.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ Fired when a connection timeout occurs.
 
 Received a message from the remote peer.
 
+### `peer.on('disconnect', function () {})`
+
+Fired when the peer connection is lost.
+
 ### `peer.on('reconnect', function (data) {})`
 
 Fired when a reconnection occurs.

--- a/server/index.js
+++ b/server/index.js
@@ -142,6 +142,7 @@ function SocketPeerServer(opts) {
       }
 
       if (client.peer) {
+        client.peer.sendMessage('peer.lost');
         peersWaiting[client.pairCode] = client.peer;
         closeConnection(client.pairCode);
       }


### PR DESCRIPTION
I'd like to be able to determine whether or not a peer is still listening upstream. The `connect` event is fired when a peer joins the room, but no event indicates that the peer has left.  `disconnect` seems like the intuitive opposite of `connect`, although it's worth noting that a `disconnect` won't trigger any reconnection attempts — the websocket to the server is still open.
